### PR TITLE
Add history and psychosocial precursors to scoring model

### DIFF
--- a/research.html
+++ b/research.html
@@ -118,6 +118,36 @@
         <div style="margin-top:6px"><label>Peer norms override (0–1)</label><input id="peer_override" type="number" min="0" max="1" step="0.01" placeholder="Optional"></div>
       </div>
 
+      <details>
+        <summary style="font-weight:700">History & Psychosocial Precursors (check all that apply)</summary>
+        <div class="expander">
+          <!-- Childhood sexual abuse -->
+          <div><input class="hx_cb" type="checkbox" data-val="0.06" id="hx_csa_subst">
+            <label for="hx_csa_subst">Childhood sexual abuse — substantiated/clear record</label></div>
+          <div><input class="hx_cb" type="checkbox" data-val="0.04" id="hx_csa_suspected">
+            <label for="hx_csa_suspected">Childhood sexual abuse — suspected/unclear</label></div>
+
+          <!-- Physical abuse -->
+          <div><input class="hx_cb" type="checkbox" data-val="0.02" id="hx_phys_child">
+            <label for="hx_phys_child">Childhood physical abuse (documented)</label></div>
+          <div><input class="hx_cb" type="checkbox" data-val="0.03" id="hx_ipv_adult">
+            <label for="hx_ipv_adult">Adult partner physical abuse (history of IPV)</label></div>
+
+          <!-- Attachment style -->
+          <div><input class="hx_cb" type="checkbox" data-val="0.02" id="hx_attach_anx">
+            <label for="hx_attach_anx">Attachment insecurity — anxious</label></div>
+          <div><input class="hx_cb" type="checkbox" data-val="0.02" id="hx_attach_avoid">
+            <label for="hx_attach_avoid">Attachment insecurity — avoidant</label></div>
+
+          <!-- ACEs aggregate (don’t double-count CSA/phys) -->
+          <div style="margin-top:8px">
+            <label for="hx_aces">ACEs (0–10, exclude items already checked above)</label>
+            <input id="hx_aces" type="number" min="0" max="10" step="1" value="0" />
+            <div class="help">Adds +0.01 per ACE, capped at +0.06. If CSA/physical abuse are checked above, do not also count them in the ACE total.</div>
+          </div>
+        </div>
+      </details>
+
       <div class="field">
   <label>Country / Cultural permissiveness</label>
   <select id="country_select">
@@ -242,13 +272,14 @@ const SCALES = {
   sensation: { weight: 0.10, min:0, max:100 },
   age: { weight: 0.10, peakMin:20, peakMax:29 },
   alcohol: { weights: { none:0, light:0.15, moderate:0.30, heavy:0.45 }, party_multiplier: 1.08 },
-  app: { weight:0.12 },
-  peer: { per_check:0.02, cap:0.08 },
-  culture: { mapping: { US:0.5, SE:0.8, BR:0.75, JP:0.35 }, weight:0.15 },
-  religion: { high: -0.06 },
-  race_mods: { none:0, white:0, black:-0.02, asian:-0.02, latino:0 },
-  interactions: { gender_app:0.03, race_app:0.03 }
-};
+    app: { weight:0.12 },
+    peer: { per_check:0.02, cap:0.08 },
+    culture: { mapping: { US:0.5, SE:0.8, BR:0.75, JP:0.35 }, weight:0.15 },
+    religion: { high: -0.06 },
+    race_mods: { none:0, white:0, black:-0.02, asian:-0.02, latino:0 },
+    history: { cap: 0.12, ace_per: 0.01, ace_cap: 0.06 },
+    interactions: { gender_app:0.03, race_app:0.03 }
+  };
 
 // ---------------- Utilities ----------------
 function clamp(x,a,b){return Math.max(a,Math.min(b,x));}
@@ -293,9 +324,9 @@ function readInputs(){
   const countryManual = parseFloat(document.getElementById('country_manual').value);
   const religion = parseInt(document.getElementById('religion').value);
   const interactions = document.getElementById('interactions').value === '1';
-  const appUse = parseInt(document.getElementById('app_use').value) === 1;
+    const appUse = parseInt(document.getElementById('app_use').value) === 1;
 
-  // SOI derivation: if direct available, use it; else combine checks to synthetic 0-1
+    // SOI derivation: if direct available, use it; else combine checks to synthetic 0-1
   let soiNorm;
   if(!isNaN(soiDirect)){
     soiNorm = clamp((soiDirect - SCALES.soi.min)/(SCALES.soi.max - SCALES.soi.min), 0, 1);
@@ -319,11 +350,21 @@ function readInputs(){
 
   // Culture value (UPDATED to use dropdown + urban toggle)
   let cultureVal;
-  if(country === 'MANUAL') cultureVal = clamp(countryManual || 0.5,0,1);
-  else cultureVal = getCountryScore();
+    if(country === 'MANUAL') cultureVal = clamp(countryManual || 0.5,0,1);
+    else cultureVal = getCountryScore();
 
-  return { age, gender, race, soiNorm, sensationNorm, alcoholVal, partySetting, peerNorm, cultureVal, religion, interactions, appUse };
-}
+    // History & psychosocial precursors
+    const hxChecks = Array.from(document.querySelectorAll('.hx_cb'))
+      .filter(c => c.checked)
+      .map(c => parseFloat(c.getAttribute('data-val')) || 0);
+
+    const aceRaw = parseInt(document.getElementById('hx_aces')?.value, 10);
+    const hxACE = isNaN(aceRaw) ? 0 : clamp(aceRaw * (SCALES.history?.ace_per ?? 0.01), 0, SCALES.history?.ace_cap ?? 0.06);
+
+    return { age, gender, race, soiNorm, sensationNorm, alcoholVal, partySetting, peerNorm,
+      cultureVal, religion, interactions, appUse,
+      hxChecks, hxACE };
+  }
 
 // ---------------- Scoring function ----------------
 function computeScore(inputs){
@@ -337,11 +378,20 @@ function computeScore(inputs){
   if(inputs.partySetting) alcContrib *= SCALES.alcohol.party_multiplier; // slight multiplier
   const appContrib = inputs.appUse ? SCALES.app.weight : 0;
   const peerContrib = inputs.peerNorm; // already in 0-0.08
-  const cultContrib = SCALES.culture.weight * inputs.cultureVal; // up to 0.15
-  const raceAdj = SCALES.race_mods[inputs.race] || 0;
-  const religAdj = inputs.religion ? SCALES.religion.high : 0;
+    const cultContrib = SCALES.culture.weight * inputs.cultureVal; // up to 0.15
+    const raceAdj = SCALES.race_mods[inputs.race] || 0;
+    const religAdj = inputs.religion ? SCALES.religion.high : 0;
 
-  let raw = base + g + soiContrib + sensContrib + ageC + alcContrib + appContrib + peerContrib + cultContrib + raceAdj + religAdj;
+    // Sum history contributions with caps
+    const hxSum = clamp(
+      (inputs.hxChecks?.reduce((a,b)=>a+b,0) || 0) + (inputs.hxACE || 0),
+      0,
+      SCALES.history?.cap ?? 0.12
+    );
+
+    let raw = base + g + soiContrib + sensContrib + ageC + alcContrib + appContrib
+            + peerContrib + cultContrib + raceAdj + religAdj
+            + hxSum;
 
   // optional interactions (small multiplicative adjustments)
   if(inputs.interactions && inputs.appUse){


### PR DESCRIPTION
## Summary
- add History & Psychosocial Precursors checklist to the form
- capture ACE counts and history checkboxes in inputs
- include capped history contribution in final score computation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896686d6924832fb7d8e401a81d575f